### PR TITLE
Make links non-absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Opencast is a flexible and customizable video capture and distribution system fo
 
 {% endfor %}
 
-[News Archive...](/news)
+[News Archive...](news)
 
 
 ---
@@ -31,8 +31,8 @@ Opencast is a flexible and customizable video capture and distribution system fo
 {% include fullsizebox.html 
 title="Schedule"
 description="Schedule events to automatically record based on a pre-defined timetable and, capture both video of the presenter and the  PC screen."
-image="/assets/img/schedule.png"
-linkurl="/software"
+image="assets/img/schedule.png"
+linkurl="software"
 align="left"
 backgroundcolor=site.data.colors.box
 %}
@@ -40,16 +40,16 @@ backgroundcolor=site.data.colors.box
 {% include fullsizebox.html 
 title="Edit"
 description="Bulk edit and trim video recordings. The editor provides graphical visualization of elements such as audio can significantly reduce editing time."
-image="/assets/img/edit.png"
-linkurl="/software"
+image="assets/img/edit.png"
+linkurl="software"
 align="right"
 %}
 
 {% include fullsizebox.html 
 title="Process"
 description="A scalable infrastructure to encode video, generate metadata and preview images, create captioning and bulk edit to support video processing at scale."
-image="/assets/img/events.png"
-linkurl="/software"
+image="assets/img/events.png"
+linkurl="software"
 align="left"
 backgroundcolor=site.data.colors.box
 %}
@@ -57,16 +57,16 @@ backgroundcolor=site.data.colors.box
 {% include fullsizebox.html 
 title="Distribute"
 description="Publish recordings for download or on-demand viewing via YouTube, RSS, Atom-feeds or with OAI-PMH."
-image="/assets/img/distribute.png"
-linkurl="/software"
+image="assets/img/distribute.png"
+linkurl="software"
 align="right"
 %}
 
 {% include fullsizebox.html 
 title="Playback"
 description="The media player is a standalone application or embedded on blogs, wikis or a content management system."
-image="/assets/img/playback.png"
-linkurl="/software"
+image="assets/img/playback.png"
+linkurl="software"
 align="left"
 backgroundcolor=site.data.colors.box
 %}
@@ -74,8 +74,8 @@ backgroundcolor=site.data.colors.box
 {% include fullsizebox.html 
 title="Manage"
 description="A robust dashboard to manage, configure and track the status and performance of video content and distribution channels."
-image="/assets/img/manage.png"
-linkurl="/software"
+image="assets/img/manage.png"
+linkurl="software"
 align="right"
 %}
 
@@ -85,10 +85,10 @@ align="right"
 
 # Get Involved
 
-Opencast has an active, helpful and engaging community. [Here you can find information on how to get in contact with us](/communication).
+Opencast has an active, helpful and engaging community. [Here you can find information on how to get in contact with us](communication).
 
 ---
 
 # Trusted by a Collection of Innovative Organizations including these 6 Institutions
-[<img class="center-image" src="/assets/img/opencast-homepage-logos-rev2.png">](/users)
+[<img class="center-image" src="assets/img/opencast-homepage-logos-rev2.png">](users)
 

--- a/_includes/software.html
+++ b/_includes/software.html
@@ -17,4 +17,4 @@
     </div>
   </a>  
 </div>
-<div class="content-more"><a href="/getting-started" style="float:right;">Tell me more...</a></div>
+<div class="content-more"><a href="getting-started" style="float:right;">Tell me more…</a></div>

--- a/_includes/software_menu.html
+++ b/_includes/software_menu.html
@@ -2,10 +2,10 @@
         <nav class="navbar navbar-default navigation">
             <div class="navigation-bar">
                 <ul class="nav navbar-nav navigation-list">
-                    <li class="nav-item menu-item sub-menu"><a class="sub-nav-link" href="/getting-started">Install</a></li>
-                    <li class="nav-item menu-item sub-menu"><a class="sub-nav-link" href="/features">Features</a></li>
-                    <li class="nav-item menu-item sub-menu"><a class="sub-nav-link" href="/benefits">Benefits</a></li>
-                    <li class="nav-item menu-item sub-menu"><a class="sub-nav-link" href="/faq">FAQ</a></li>                       
+                    <li class="nav-item menu-item sub-menu"><a class="sub-nav-link" href="getting-started">Install</a></li>
+                    <li class="nav-item menu-item sub-menu"><a class="sub-nav-link" href="features">Features</a></li>
+                    <li class="nav-item menu-item sub-menu"><a class="sub-nav-link" href="benefits">Benefits</a></li>
+                    <li class="nav-item menu-item sub-menu"><a class="sub-nav-link" href="faq">FAQ</a></li>                       
                 </ul>
             </div>
         </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8"> {% seo %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
@@ -30,15 +30,15 @@
     <section class="main-menu">
         <nav class="navbar navbar-default navigation">
             <div class="logo-box">
-                <a class="navbar-brand" href="/"><img src="/assets/img/opencast.svg" alt="Opencast Logo" class="opencast-logo"/></a>
+                <a class="navbar-brand" href="/"><img src="assets/img/opencast.svg" alt="Opencast Logo" class="opencast-logo"/></a>
             </div>
             <div class="navigation-bar">
                 <ul class="nav navbar-nav navigation-list">
-                    <li class="nav-item menu-item"><a class="nav-link" href="/software">Software</a></li>
-                    <li class="nav-item menu-item"><a class="nav-link" href="/community">Community</a></li>
-                    <li class="nav-item menu-item"><a class="nav-link" href="/marketplace">Marketplace</a></li>
-                    <li class="nav-item menu-item"><a class="nav-link" href="/events">Events</a></li>
-                    <li class="nav-item menu-item"><a class="nav-link" href="/sponsors">Sponsors</a></li>
+                    <li class="nav-item menu-item"><a class="nav-link" href="software">Software</a></li>
+                    <li class="nav-item menu-item"><a class="nav-link" href="community">Community</a></li>
+                    <li class="nav-item menu-item"><a class="nav-link" href="marketplace">Marketplace</a></li>
+                    <li class="nav-item menu-item"><a class="nav-link" href="events">Events</a></li>
+                    <li class="nav-item menu-item"><a class="nav-link" href="sponsors">Sponsors</a></li>
                 </ul>
             </div>
         </nav>
@@ -54,19 +54,19 @@
     <section class="main-content">
         {{ content }}
     </section>
-    
+
         <div class="footer">
             <div class="icons">
             <a href="https://twitter.com/openmatter"><i class="fab fa-twitter-square"></i></a>
             <a href="https://www.facebook.com/opencast"><i class="fab fa-facebook-square"></i></a>
             <a href="https://www.youtube.com/channel/UCyKuUY_V_5Em5OSa59AUuVg"><i class="fab fa-youtube-square"></i></a>
             </div>
-                
+
             <section class="main-menu-footer">
         <nav class="navbar navbar-default navigation">
             <div class="navigation-bar-footer">
                 <ul class="nav navbar-nav navigation-list-footer">
-                    <li class="nav-item menu-item"><a class="nav-link-footer" href="/software">Software</a>
+                    <li class="nav-item menu-item"><a class="nav-link-footer" href="software">Software</a>
                     <ul class="sublinks">
                         <li><a href="/install">&bull; Install</a></li>
                         <li><a href="/features">&bull; Features</a></li>
@@ -74,33 +74,33 @@
                         <li><a href="/faq">&bull; FAQ</a></li>
                     </ul>
                     </li>
-                    <li class="nav-item menu-item"><a class="nav-link-footer" href="/community">Community</a>
+                    <li class="nav-item menu-item"><a class="nav-link-footer" href="community">Community</a>
                     <ul class="sublinks">
-                        <li><a href="/users">&bull; Users</a></li>
-                        <li><a href="/communication">&bull; Communication</a></li>
-                        <li><a href="/events">&bull; Events</a></li>
-                        <li><a href="/people">&bull; People</a></li>
-                        <li><a href="/governance">&bull; Governance</a></li>
+                        <li><a href="users">&bull; Users</a></li>
+                        <li><a href="communication">&bull; Communication</a></li>
+                        <li><a href="events">&bull; Events</a></li>
+                        <li><a href="people">&bull; People</a></li>
+                        <li><a href="governance">&bull; Governance</a></li>
                     </ul>
                     </li>
-                    <li class="nav-item menu-item"><a class="nav-link-footer" href="/marketplace">Marketplace</a>
+                    <li class="nav-item menu-item"><a class="nav-link-footer" href="marketplace">Marketplace</a>
                     <ul class="sublinks">
-                        <li><a href="/tools">&bull; Tools</a></li>
-                        <li><a href="/hardware">&bull; Hardware Vendors</a></li>
-                        <li><a href="/support">&bull; Commercial Support</a></li>
+                        <li><a href="tools">&bull; Tools</a></li>
+                        <li><a href="hardware">&bull; Hardware Vendors</a></li>
+                        <li><a href="support">&bull; Commercial Support</a></li>
                     </ul></li>
-                    <li class="nav-item menu-item"><a class="nav-link-footer" href="/events">Events</a></li>
-                    <li class="nav-item menu-item"><a class="nav-link-footer" href="/sponsors">Sponsors</a></li>
-                    <li class="nav-item menu-item"><a class="nav-link-footer" href="/impress">Contact/Impress</a></li>
+                    <li class="nav-item menu-item"><a class="nav-link-footer" href="events">Events</a></li>
+                    <li class="nav-item menu-item"><a class="nav-link-footer" href="sponsors">Sponsors</a></li>
+                    <li class="nav-item menu-item"><a class="nav-link-footer" href="impress">Contact/Impress</a></li>
                 </ul>
                 </ul>
             </div>
         </nav>
         <div class="apero_logo">
         <a href="http://apereo.org"> <img src="https://www.apereo.org/sites/all/themes/apereo/images/logo.png"> </a>
-        AN APEREO PROJECT  
+        AN APEREO PROJECT
         </div>
-    </section>  
+    </section>
         </div>
     {% if site.google_analytics %}
     <script>
@@ -117,7 +117,7 @@
     })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
     ga('create', '{{ site.google_analytics }}', 'auto');
-    ga('set', 'anonymizeIp', true);    
+    ga('set', 'anonymizeIp', true);
     ga('send', 'pageview');
     </script>
     {% endif %}

--- a/software.md
+++ b/software.md
@@ -27,34 +27,34 @@ description: Opencast is an open source solution for automated video capture and
 
 {% include fullsizebox.html 
 title="Install Opencast"
-description="Here you will find a test server, installation instructions and the general documenation for Opencast. [Read more...](/install)"
-image="/assets/img/large-playback_install.png"
-linkurl="/software"
+description="Here you will find a test server, installation instructions and the general documenation for Opencast. [Read more…](install)"
+image="assets/img/large-playback_install.png"
+linkurl="software"
 align="right"
 %}
 
 {% include fullsizebox.html 
 title="Features"
-description="What makes Opencast such a great software? Have a look at out feature highlights. [Read more...](/features)"
-image="/assets/img/features.png"
-linkurl="/software"
+description="What makes Opencast such a great software? Have a look at out feature highlights. [Read more…](features)"
+image="assets/img/features.png"
+linkurl="software"
 align="right"
 backgroundcolor=site.data.colors.box
 %}
 
 {% include fullsizebox.html 
 title="Benefits"
-description="Additional to the features there are more reasons why Opencast is a reasonable choice for a video management system ant your institution. [Read more...](/benefits)"
-image="/assets/img/benefits.png"
-linkurl="/software"
+description="Additional to the features there are more reasons why Opencast is a reasonable choice for a video management system ant your institution. [Read more…](benefits)"
+image="assets/img/benefits.png"
+linkurl="software"
 align="right"
 %}
 
 {% include fullsizebox.html 
 title="Frequently Asked Questions"
-description="Here are some frequently asked questions regarding Opencast. This will help you determine if it’s the right solution for your organization. [Read more...](/faq)"
-image="/assets/img/large-manage_faq.png"
-linkurl="/software"
+description="Here are some frequently asked questions regarding Opencast. This will help you determine if it’s the right solution for your organization. [Read more…](faq)"
+image="assets/img/large-manage_faq.png"
+linkurl="software"
 align="right"
 backgroundcolor=site.data.colors.box
 %}
@@ -62,5 +62,5 @@ backgroundcolor=site.data.colors.box
 ---
 
 # See why leading organizations chose Opencast.
-Visit our [Users](/users) page in the community section for more report from institutions that use Opencast.
-[<img class="center-image" src="/assets/img/opencast-homepage-logos-rev2.png">](/users)
+Visit our [Users](users) page in the community section for more report from institutions that use Opencast.
+[<img class="center-image" src="assets/img/opencast-homepage-logos-rev2.png">](users)

--- a/support.md
+++ b/support.md
@@ -8,7 +8,7 @@ description: "Opencast has a group of partners that can help you make the most i
 {% include imagebox.html 
 title="ELAN e.V."
 description="ELAN e.V. is a nonprofit association, which offers commercial support and development for Opencast."
-image="/assets/img/elan.png"
+image="assets/img/elan.png"
 linkurl="https://www.elan-ev.de"
 linktext="Learn More"
 backgroundcolor=site.data.colors.box
@@ -18,7 +18,7 @@ size="large"
 {% include imagebox.html 
 title="plapadoo"
 description="A startup that offers software development for Opencast and consulting."
-image="/assets/img/plapadoo.png"
+image="assets/img/plapadoo.png"
 linkurl="https://en.plapadoo.com/blog"
 linktext="Learn More"
 backgroundcolor=site.data.colors.box
@@ -28,7 +28,7 @@ size="large"
 {% include imagebox.html 
 title="ssystems!"
 description="ssystems! offer support in integrating Opencast with other campus systems."
-image="/assets/img/ssystems.png"
+image="assets/img/ssystems.png"
 linkurl="https://www.ssystems.de"
 linktext="Learn More"
 backgroundcolor=site.data.colors.box
@@ -38,7 +38,7 @@ size="large"
 {% include imagebox.html 
 title="Teltek"
 description="TELTEK Video Research provides \"on premises\" and cloud hosted solutions based on Opencast. TELTEK offers to combine Opencast with PuMuKIT (an Open Video oriented CMS) to build end-to-end Campus-wide video solutions."
-image="/assets/img/teltek.png"
+image="assets/img/teltek.png"
 linkurl="http://teltek.es"
 linktext="Learn More"
 backgroundcolor=site.data.colors.box

--- a/tools.md
+++ b/tools.md
@@ -11,7 +11,7 @@ title="LectureSight"
 description="LectureSight is a free and open-source tracking tool that allows to steer a pan-tilt camera based on data gathered by a separate webcam. The aim of this project is to offer a more vivid video of the lecture and show more details of what is going on in the classroom. This will enable an automated recording of a lecture that uses the blackboard, i.e.
 
 [LectureSight Homepage](https://opencast.jira.com/wiki/spaces/LECTURESIGHT/overview)"
-image="/assets/img/ls-running.png"
+image="assets/img/ls-running.png"
 linkurl="https://opencast.jira.com/wiki/spaces/LECTURESIGHT/overview"
 align="left"
 imagewidth="50%"
@@ -22,7 +22,7 @@ title="Track4K"
 description="Modern cameras can capture up to 4K resultion. This offers more detail than most current displays can show. Track4K analyses the high-res video and crops videos based on the actions within the video. There is also an interactive mode for the Paella player that automatically zooms in but allows the user to change the viewing area manually.
 
 [Track4K Homepage](http://track4k.co.za/index.html)"
-image="/assets/img/track4k.jpg"
+image="assets/img/track4k.jpg"
 linkurl="http://track4k.co.za/index.html"
 align="left"
 imagewidth="50%"
@@ -38,7 +38,7 @@ title="Galicaster"
 description="Galicaster, from Teltek, is currently the most popular capture software that works together with Opencast. Additional to recording devices with the Galicaster software that can be purchased from Teltek, this software under a non-commercial open-source licence that allows universities to use the software for free on their computers.
 
 [Galicaster Homepage](https://wiki.teltek.es/display/Galicaster/Galicaster+project+Home)"
-image="/assets/img/galicaster-ui.png"
+image="assets/img/galicaster-ui.png"
 linkurl="https://wiki.teltek.es/display/Galicaster/Galicaster+project+Home"
 align="left"
 imagewidth="50%"
@@ -51,7 +51,7 @@ description="PyCA is a fully functional Opencast capture agent written in Python
 PyCA can be run on almost any kind of devices: A regular PC equipped with capture cards, a server to capture network streams, small boards or embedded devices like Raspberry Pi, Beagleboard, …
 
 [PyCA on Github](https://github.com/opencast/pyCA)"
-image="/assets/img/Screenshot-from-2017-03-13-17-43-53.png"
+image="assets/img/Screenshot-from-2017-03-13-17-43-53.png"
 linkurl="https://github.com/opencast/pyCA"
 align="left"
 imagewidth="50%"
@@ -63,7 +63,7 @@ title="TheRec"
 description="TheRec is a free and open-source recording software for Windows 7+. Currently TheRec does not offer all features that a regular capture agent provides, as it does not support scheduling and uploading from Opencast. For an automated upload it relies on MHRI. Unlike other recording tools TheRec is easy to install and to configure. It supports a wide variety of capture cards that are compatible with Microsoft DirectShow. The number of simultanous streams that can be recorded is only limited by the speed of the computer.
 
 [TheRec Homepage](https://elan-ev.de/produkte_av_therec_english.php)"
-image="/assets/img/therec.png"
+image="assets/img/therec.png"
 linkurl="https://elan-ev.de/produkte_av_therec_english.php"
 align="left"
 imagewidth="50%"
@@ -78,7 +78,7 @@ title="Galicaster Dashboard"
 description="The Galicaster Dashboard is designed to monitor Capture Agents, especially Galicaster Capture Agents. The Tool gives you an overview of your recording devices, with their current status and a preview of the signals that the agent is currently recording.
 
 [Galicaster Dashboard Homepage](https://wiki.teltek.es/display/Galicaster/Galicaster+Dashboard)"
-image="/assets/img/gc-dashboard.png"
+image="assets/img/gc-dashboard.png"
 linkurl="https://wiki.teltek.es/display/Galicaster/Galicaster+Dashboard"
 align="left"
 imagewidth="50%"
@@ -96,7 +96,7 @@ description="The Paella Player is a free and open-source alternative player for 
 ### Now included in Opencast 5
 
 [Paella Player Homepage](http://paellaplayer.upv.es/)"
-image="/assets/img/paellaplayer.png"
+image="assets/img/paellaplayer.png"
 linkurl="https://wiki.teltek.es/display/Galicaster/Galicaster+Dashboard"
 align="left"
 backgroundcolor=site.data.colors.greenbox
@@ -108,7 +108,7 @@ title="Annotating Academic Video Tool"
 description="Annotating Academic Video is a free and open-source annotation tool. The aim of this software is provide teacher and learners with an easy to use tool to annotate videos.
 
 [Annotating Academic Video Tool Homepage](https://bitbucket.org/opencast-community/annotation-tool)"
-image="/assets/img/annotationtool.png"
+image="assets/img/annotationtool.png"
 linkurl="https://bitbucket.org/opencast-community/annotation-tool"
 align="left"
 imagewidth="50%"
@@ -127,7 +127,7 @@ Currently, there are two Opencast Stream Security plugins available:
 
 - [Apache HTTP Stream Security Plugin](https://bitbucket.org/opencast-community/apache-httpd-stream-security-plugin)
 - [Wowza Stream Security Plugin](https://bitbucket.org/opencast-community/wowza-stream-security-plugin/src)"
-image="/assets/img/login-1203603_960_720.png"
+image="assets/img/login-1203603_960_720.png"
 linkurl="https://bitbucket.org/opencast-community/apache-httpd-stream-security-plugin"
 align="left"
 imagewidth="50%"


### PR DESCRIPTION
This patch starts making links non-absolute to allow the page to be
displayed in sub-directories. Otherwise, it is hard to fork and test
changes since the pages URLs will look like this:

  https://lkiesow.github.io/opencast.github.io