### PR TITLE
Fix links to installation instructions

### DIFF
--- a/_posts/2018-03-28-opencast4-3-released.md
+++ b/_posts/2018-03-28-opencast4-3-released.md
@@ -34,4 +34,4 @@ The new features for this release are:
 
 A full list of changes can be found in the [official release notes](https://docs.opencast.org/r/4.x/admin/releasenotes/).
 
-Visit the [download section](http://www.opencast.org/software/download) for more information on how to get Opencast 4.0.
+Visit the [installation guide](https://docs.opencast.org/r/4.x/admin/installation/) for more information on how to get Opencast 4.

--- a/_posts/2018-05-30-opencast3-6-released.md
+++ b/_posts/2018-05-30-opencast3-6-released.md
@@ -91,4 +91,4 @@ The Opencast codebase is now located on [GitHub](https://github.com/opencast/ope
 
 A full list of changes can be found in the [official release notes](https://docs.opencast.org/r/3.x/admin/releasenotes/).
 
-Visit the [download section](http://www.opencast.org/software/download) for more information on how to get Opencast 3.0.
+Visit the [installation guide](https://docs.opencast.org/r/3.x/admin/installation/) for more information on how to get Opencast 3.

--- a/_posts/2018-05-31-opencast4-4-released.md
+++ b/_posts/2018-05-31-opencast4-4-released.md
@@ -34,4 +34,4 @@ The new features for this release are:
 
 A full list of changes can be found in the [official release notes](https://docs.opencast.org/r/4.x/admin/releasenotes/).
 
-Visit the [download section](http://www.opencast.org/software/download) for more information on how to get Opencast 4.0.
+Visit the [installation guide](https://docs.opencast.org/r/4.x/admin/installation/) for more information on how to get Opencast 4.

--- a/_posts/2018-06-12-opencast5-0-released.md
+++ b/_posts/2018-06-12-opencast5-0-released.md
@@ -53,4 +53,4 @@ The Opencast codebase is now located on [GitHub](https://github.com/opencast/ope
 
 A full list of changes can be found in the [official release notes](https://docs.opencast.org/r/5.x/admin/releasenotes/).
 
-Visit the [download section](http://www.opencast.org/software/download) for more information on how to get Opencast 5.0.
+Visit the [installation guide](https://docs.opencast.org/r/5.x/admin/installation/) for more information on how to get Opencast 5.


### PR DESCRIPTION
This patch fixes the links to the specific installation instructions in
the news articles about Opencast releases.