### PR TITLE
Fix People Page

### DIFF
--- a/people.md
+++ b/people.md
@@ -8,47 +8,18 @@ description: "These developers, committers and institutions are actively working
 
 Committers are active developers or other active contributors that help with their activities to keep the software alive.
 
-<img  src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Christian Greweling](https://opencast.jira.com/wiki/display/~cgreweling)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Greg Logan](https://opencast.jira.com/wiki/display/~greg_logan)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[James Perrin](https://opencast.jira.com/wiki/display/~james.perrin)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Karen Dolan](https://opencast.jira.com/wiki/display/~karen)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Lars Kiesow](https://opencast.jira.com/wiki/display/~lkiesow)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Matjaz Rihtar](https://opencast.jira.com/wiki/display/~matjaz)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Michael Stypa](https://opencast.jira.com/wiki/display/~mstypa)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Rubén Pérez](https://opencast.jira.com/wiki/display/~ruben.perez)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Rute Santos](https://opencast.jira.com/wiki/display/~rsantos)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Rüdiger Rolf](https://opencast.jira.com/wiki/display/~rrolf)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Stephen Marquard](https://opencast.jira.com/wiki/display/~smarquard)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Sven Stauber](https://opencast.jira.com/wiki/display/~staubesv)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Tobias Schiebeck](https://opencast.jira.com/wiki/display/~ts23)
-
-<img src="https://opencast.jira.com/wiki/images/icons/user_bw_16.gif">
-[Waldmar Smirnow](https://opencast.jira.com/wiki/display/~waldemarsmirnow)
+- [Christian Greweling](https://github.com/CGreweling)
+- [Greg Logan](https://github.com/gregorydlogan)
+- [James Perrin](https://github.com/TurRil)
+- [Karen Dolan](https://github.com/karendolan)
+- [Lars Kiesow](https://github.com/lkiesow)
+- [Michael Stypa](https://github.com/doofy)
+- [Rute Santos](https://github.com/rute-santos)
+- [Rüdiger Rolf](https://github.com/rrolf)
+- [Stephen Marquard](https://github.com/smarquard)
+- [Sven Stauber](https://github.com/staubesv)
+- [Tobias Schiebeck](https://github.com/ts23)
+- [Waldmar Smirnow](https://github.com/wsmirnow)
 
 ## Committers Emeritus
 The following people were committers at one time and have contributed to the project, but are no longer active committers.
@@ -58,16 +29,16 @@ The following people were committers at one time and have contributed to the pro
 - Edmore Moyo, University of Cape Town
 - Eduardo Alonso, University of Vigo
 - Jaime Gago, Entwine
-- Markus Ketterl, University of Osnabrueck
-- Markus Moorman, University of Osnabrueck
+- Markus Ketterl, University of Osnabrück
+- Markus Moorman, University of Osnabrück
 - Michelle Ziegmann, University of California Berkeley
-- Stefan Altevogt, University of Osnabrueck
+- Stefan Altevogt, University of Osnabrück
 - Kristofor Amundson, University of Saskatchewan
-- Johannes Emden, University of Osnabrueck
+- Johannes Emden, University of Osnabrück
 - Adam Hochman, University of California Berkeley
 - Jamie Hodge, University of Copenhagen
 - Josh Holtzman, University of California Berkeley
-- Andre Klassen, University of Osnabrueck
+- Andre Klassen, University of Osnabrück
 - Kenneth Lui
 - Susana Ozores, University of Vigo
 - Bostjan Pajntar, Jozef Stefan Institute
@@ -81,8 +52,11 @@ The following people were committers at one time and have contributed to the pro
 - Lukas Rohner, Entwine/Extron
 - Christoph Driessen, Entwine/Extron
 - Basil Brunner, Entwine/Extron
+- Rubén Pérez, University of Cologne
+- Matjaz Rihtar, Jozef Stefan Institute
 
-<h1 id="board">Opencast Board Members</h1>
+# Opencast Board Members
+
 The Opencast Community elects a board that looks after the overall status and direction of the project and the community. The board organizes events like the Opencast Summit and takes care of the marketing of Opencast as a product. It also manages the funds of the projects.
 
 - Olaf A. Schulte, ETH Zurich, Chair
@@ -92,9 +66,6 @@ The Opencast Community elects a board that looks after the overall status and di
 - Stephen Marquard, University of Cape Town
 - Carlos Turró Ribalta, Universitat Politécnica de Valencia (selected member)
 - Rüdiger Rolf, University of Osnabruck (selected member)
-
-# Opencast Sponsors
-Thank you to the following sponsor(s) for their support to advance the Opencast project. More details can be found [here](http://www.opencast.org/sponsors).
 
 # Our Supporters
 These institutions have provided financial, technical, or personnel suppport to advance the Opencast project. Thank you!


### PR DESCRIPTION
This patch fixes the list of committers which previously liked an
internal Jira page you could not access if you are not logged into Jira.
It also fixes a few more likes and removes the weird description of
sponsors since they got a page on their own anyway.