### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+sudo: false
+cache: bundler
+script:
+  - bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
This patch enables Travis CI which will build pull requests before they
are merged so that merges will not break the build as easily anymore.