### PR TITLE
Redirect for opencast.org/matterhorn to opencast.org for compatibility with old links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+redirect_from: "/matterhorn"
+
 Opencast is a flexible, scalable and reliable video capture, distribution, and management system for academic institutions. Opencast is built by a growing community of developers in collaboration with leading universities and organizations worldwide.
 
 {% include software.html %}


### PR DESCRIPTION
I noticed some sites have a broken link to http://opencast.org/matterhorn. This pull uses strategy from Greg's commit 22e27b57 to redirect the old matterhorn link to the main page. 